### PR TITLE
Use smaller git snapshot over larger release tar-ball

### DIFF
--- a/.scripts/logging_utils.sh
+++ b/.scripts/logging_utils.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Provide a unified interface for the different logging
+# utilities CI providers offer. If unavailable, provide
+# a compatible fallback (e.g. bare `echo xxxxxx`).
+
+function startgroup {
+    # Start a foldable group of log lines
+    # Pass a single argument, quoted
+    case ${CI:-} in
+        azure )
+            echo "##[group]$1";;
+        travis )
+            echo "$1"
+            echo -en 'travis_fold:start:'"${1// /}"'\\r';;
+        * )
+            echo "$1";;
+    esac
+}
+
+function endgroup {
+    # End a foldable group of log lines
+    # Pass a single argument, quoted
+    case ${CI:-} in
+        azure )
+            echo "##[endgroup]";;
+        travis )
+            echo -en 'travis_fold:end:'"${1// /}"'\\r';;
+    esac
+}

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -5,6 +5,10 @@
 # changes to this script, consider a proposal to conda-smithy so that other feedstocks can also
 # benefit from the improvement.
 
+source .scripts/logging_utils.sh
+
+startgroup "Configure Docker"
+
 set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
@@ -65,7 +69,9 @@ DOCKER_RUN_ARGS="${CONDA_FORGE_DOCKER_RUN_ARGS}"
 if [ -z "${CI}" ]; then
     DOCKER_RUN_ARGS="-it ${DOCKER_RUN_ARGS}"
 fi
+endgroup "Configure Docker"
 
+startgroup "Start Docker"
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 docker run ${DOCKER_RUN_ARGS} \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) 2015-2020, conda-forge contributors
+Copyright (c) 2015-2021, conda-forge contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -139,9 +139,9 @@ build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:
  * If the version of a package **is not** being increased, please add or increase
-   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string).
+   the [``build/number``](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#build-number-and-string).
  * If the version of a package **is** being increased, please remember to return
-   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string)
+   the [``build/number``](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#build-number-and-string)
    back to 0.
 
 Feedstock Maintainers

--- a/recipe/JOVE_LICENSE.txt
+++ b/recipe/JOVE_LICENSE.txt
@@ -1,6 +1,0 @@
-##########################################################################
-# This program is Copyright (C) 1986-2002 by Jonathan Payne.  JOVE is    #
-# provided by Jonathan and Jovehacks without charge and without          #
-# warranty.  You may copy, modify, and/or distribute JOVE, provided that #
-# this notice is included in all the source files and documentation.     #
-##########################################################################

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,8 +33,7 @@ test:
 about:
   home: https://github.com/jonmacs/jove/
   license: LicenseRef-JOVE
-  # JOVE_LICENSE.txt is a local copy of start of upstream README
-  license_file: JOVE_LICENSE.txt
+  license_file: LICENSE
   summary: JOVE - Jonathan's Own Version of Emacs
   description: |
     Jove is a compact, powerful Emacs-style text-editor. It provides the

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,11 +7,14 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/jonmacs/jove/releases/download/{{ version }}/jove-{{ version }}.tgz
-  sha256: 94300bed2b73b3b964fe9e42c652175525609d3ebf6fdefd2291d277b5ae27a2
+  # This is an asset usually uploaded to the GitHub release by the maintainers:
+  # https://github.com/jonmacs/jove/releases/download/{{ version }}/jove-{{ version }}.tgz
+  # This is the (smaller) automatic snapshot of the files under version control:
+  url: https://github.com/jonmacs/jove/archive/{{ version }}.tar.gz
+  sha256: a7c6644822a010a7baf4997f95c80b9419ce49b3dcad959325a3b1b035b85a65
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   script: 'make -f Makefile.msc && cp jjove.exe "$PREFIX/bin/jove.exe"'  # [win]
   script: 'make JOVEHOME="$PREFIX" SYSDEFS=-DDarwin install'  # [osx]


### PR DESCRIPTION
Hoping this makes no difference when building from
source, and importantly not all Jove's recent releases
on GitHub have the larger tarball asset.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

We can use either tar ball for 4.17.3.6, but this change is currently needed for 4.17.3.7 (Jan 2021) where there is currently no asset tarball.
